### PR TITLE
Restore with polymorphic bug

### DIFF
--- a/lib/paranoid2/persistence.rb
+++ b/lib/paranoid2/persistence.rb
@@ -41,6 +41,7 @@ module Paranoid2
 
     def restore_associations
       self.class.reflect_on_all_associations.each do |a|
+        next if a.polymorphic?
         next unless a.klass.paranoid?
 
         if a.collection?


### PR DESCRIPTION
Now the polymorphic association will ignored, instead of raising an error when restoring a model.
